### PR TITLE
Dropping need of extra package for DBAL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "illuminate/console": "^5.0",
         "illuminate/container": "^5.0",
         "illuminate/support": "^5.0",
-        "nayjest/laravel-doctrine-dbal": "^1.0"
+        "doctrine/dbal": "^2.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/Providers/TdbmServiceProvider.php
+++ b/src/Providers/TdbmServiceProvider.php
@@ -43,7 +43,9 @@ class TdbmServiceProvider extends ServiceProvider
             $daoNamespace = config('database.tdbm.daoNamespace', 'App\\Daos');
             $beanNamespace = config('database.tdbm.beanNamespace', 'App\\Beans');
 
-            return new Configuration($beanNamespace, $daoNamespace, $app->make('doctrine_dbal_connection'), $app->make(NamingStrategyInterface::class), $app->make(Cache::class), null, $app->make(LoggerInterface::class));
+            $db = $app->make('db');
+
+            return new Configuration($beanNamespace, $daoNamespace, $db->connection()->getDoctrineConnection(), $app->make(NamingStrategyInterface::class), $app->make(Cache::class), null, $app->make(LoggerInterface::class));
         });
 
         $this->app->singleton(TDBMService::class, function ($app) {


### PR DESCRIPTION
There is no need for the package Nayjest/Laravel_DoctrineDBAL.
DBAL support is actually baked in the Laravel connection.